### PR TITLE
Add Unmarshal2(), which returns the unread portion of the input byte slice

### DIFF
--- a/unmarshal.go
+++ b/unmarshal.go
@@ -29,6 +29,12 @@ var (
 
 // Unmarshal data serialized by python
 func Unmarshal(data []byte) (ret interface{}, retErr error) {
+	ret, _, retErr = Unmarshal2(data)
+	return
+}
+
+// Unmarshal data serialized by python, returning the unused portion.
+func Unmarshal2(data []byte) (ret interface{}, remainder []byte, retErr error) {
 	buffer := bytes.NewBuffer(data)
 	code, err := buffer.ReadByte()
 	if nil != err {
@@ -36,6 +42,7 @@ func Unmarshal(data []byte) (ret interface{}, retErr error) {
 	}
 
 	ret, retErr = unmarshal(code, buffer)
+	remainder = buffer.Bytes()
 	return
 }
 


### PR DESCRIPTION
The problem here is that in some cases, the user has a byte slice that might have multiple marshalled python objects in it.  For example, the perforce client (p4 -G) writes multiple marshalled python objects to stdout.  In most cases, I don't know how many there will be.  When I call gopymarshal.Unmarshal(), it dutifully returns the first, but gives no indication of how many bytes of my slice it consumed, or whether there might be more marshalled objects after the first.

By using Unmarshal2(), I can easily scan them all out like this:

  var output []byte = ...
  for len(output) > 0 {
     obj, output, err = gopymarshal.Unmarshal2(output)
     ... process obj ...
   }

Any chance we could merge this in?
