### PR TITLE
Use a buffer in the api

### DIFF
--- a/unmarshal.go
+++ b/unmarshal.go
@@ -28,8 +28,7 @@ var (
 )
 
 // Unmarshal data serialized by python
-func Unmarshal(data []byte) (ret interface{}, retErr error) {
-	buffer := bytes.NewBuffer(data)
+func Unmarshal(buffer *bytes.Buffer) (ret interface{}, retErr error) {
 	code, err := buffer.ReadByte()
 	if nil != err {
 		retErr = err


### PR DESCRIPTION
Hi, this PR changes the interface to Unmarshal so you can provide a stream rather than having to pre-load the entire stream into a slice. This allows the user to provide a stream which contains multiple marshalled dictionaries in sequence and unmarshall them one at a time. Requiring the user to pre-load the entire stream into a single byte slice makes that impossible.

For context, I'm working on adding a go wrapper for the Perforce command line tool and it produces a list of results as a stream of python dictionaries. I think they don't use a list so you can process each result as it comes in rather than having to wait for the entire thing to deserialize.

Let me know what you think. Thanks for the library!