### PR TITLE
fix unmatched function argument

### DIFF
--- a/unmarshal.go
+++ b/unmarshal.go
@@ -29,7 +29,7 @@ var (
 
 // Unmarshal data serialized by python
 func Unmarshal(buffer *bytes.Buffer) (ret interface{}, retErr error) {
-	ret, _, retErr = Unmarshal2(data)
+	ret, _, retErr = Unmarshal2(buffer)
 	return
 }
 


### PR DESCRIPTION
change `data` to `buffer` to match function argument.
Otherwise build fails with `github.com/hambster/gopymarshal/unmarshal.go:32:30: undefined: data`